### PR TITLE
Remove duplicate font imports from head

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet">
     <link
             rel="stylesheet"


### PR DESCRIPTION
У файлі index.html є дублюючі підключення шрифтів Google Fonts, що може уповільнювати завантаження сторінки.